### PR TITLE
ShortCircuIt: reduce redundant calls to Object#hash

### DIFF
--- a/short_circu_it/CHANGELOG.md
+++ b/short_circu_it/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Upcoming <!-- Add unreleased change notes here: -->
 
+- Remove redundant calls when fetching memoized values ([#15](https://github.com/RubyAfterAll/spicerack/pull/15))
+
 ## v0.29.1
 
 *Release Date*: 8/23/2022

--- a/short_circu_it/lib/short_circu_it.rb
+++ b/short_circu_it/lib/short_circu_it.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-require "short_circu_it/version"
-require "short_circu_it/errors"
-require "short_circu_it/memoization_store"
 require "active_support/core_ext/module"
 require "active_support/core_ext/array"
 require "active_support/concern"
 require "around_the_world"
+
+require_relative "short_circu_it/version"
+require_relative "short_circu_it/errors"
+require_relative "short_circu_it/memoization_store"
 
 module ShortCircuIt
   extend ActiveSupport::Concern
@@ -72,7 +73,7 @@ module ShortCircuIt
     #   A method or array of methods to be observed to determine memoization cache validity.
     #   If any of the observed values change, the cached value will be invalidated.
     #   By default, the object will observe itself.
-    def memoize(*method_names, observes: :itself)
+    def memoize(*method_names, observes: nil)
       method_names.map(&:to_sym).each do |method_name|
         add_memoized_observers(method_name, observes)
 
@@ -80,7 +81,7 @@ module ShortCircuIt
           method_name,
           prevent_double_wrapping_for: ShortCircuIt,
         ) do |*args, **opts|
-          memoization_store.memoize(method_name, (args + [ opts ]).hash) do
+          memoization_store.memoize(method_name, args, opts) do
             # TODO: replace with `super(*args, **opts)` when <= 2.6 support is dropped
             if RUBY_VERSION < "2.7" && opts.blank?
               super(*args)

--- a/short_circu_it/lib/short_circu_it.rb
+++ b/short_circu_it/lib/short_circu_it.rb
@@ -73,7 +73,7 @@ module ShortCircuIt
     #   A method or array of methods to be observed to determine memoization cache validity.
     #   If any of the observed values change, the cached value will be invalidated.
     #   By default, the object will observe itself.
-    def memoize(*method_names, observes: nil)
+    def memoize(*method_names, observes: :itself)
       method_names.map(&:to_sym).each do |method_name|
         add_memoized_observers(method_name, observes)
 

--- a/short_circu_it/lib/short_circu_it/memoization_store.rb
+++ b/short_circu_it/lib/short_circu_it/memoization_store.rb
@@ -25,10 +25,12 @@ module ShortCircuIt
 
       return value unless value == NOT_MEMOIZED
 
-      clear_memoization(method_name) unless current_memoization_for_method?(method_name)
+      state_hash = state_hash(method_name)
+
+      clear_memoization(method_name) unless current_memoization_for_method?(method_name, state_hash)
 
       yield.tap do |returned_value|
-        current_memoization_for_method(method_name)[argument_hash] = returned_value
+        current_memoization_for_method(method_name, state_hash)[argument_hash] = returned_value
       end
     end
 
@@ -37,7 +39,7 @@ module ShortCircuIt
     # @param *method_names [Symbol] The name of a memoized method
     # @return [Boolean] True if a value was cleared, false if not
     def clear_memoization(*method_names)
-      method_names.all? { |method_name| memoized_hash.delete(method_name.to_sym) }
+      method_names.all? { |method_name| memoized_hash.delete(method_name) }
     end
 
     # Clears all memoized values on the object
@@ -68,15 +70,19 @@ module ShortCircuIt
 
     # @param method_name [Symbol] The name of a memoized method
     # @return [Hash] A hash of memoized values for the current state of the observed objects for the given method.
-    def current_memoization_for_method(method_name)
+    def current_memoization_for_method(method_name, state_hash = nil)
+      state_hash ||= state_hash(method_name)
+
       # Memoize values inside a hash with default value of NOT_MEMOIZED
-      memoization_for_method(method_name)[state_hash(method_name)] ||= Hash.new(NOT_MEMOIZED)
+      memoization_for_method(method_name)[state_hash] ||= Hash.new(NOT_MEMOIZED)
     end
 
     # @param method_name [Symbol] The name of a memoized method
     # @return [Boolean] True if there are any memoized values for the current state of the observed objects.
-    def current_memoization_for_method?(method_name)
-      memoization_for_method(method_name).key?(state_hash(method_name))
+    def current_memoization_for_method?(method_name, state_hash = nil)
+      state_hash ||= state_hash(method_name)
+
+      memoization_for_method(method_name).key?(state_hash)
     end
 
     # @param method_name [Symbol] The name of a memoized method

--- a/short_circu_it/lib/short_circu_it/memoization_store.rb
+++ b/short_circu_it/lib/short_circu_it/memoization_store.rb
@@ -4,6 +4,8 @@ require "active_support/core_ext/module"
 
 module ShortCircuIt
   class MemoizationStore
+    NOT_MEMOIZED = Object.new
+
     delegate :memoization_observers, to: :owner
 
     # @param owner [*] The object being memoized
@@ -12,11 +14,16 @@ module ShortCircuIt
     end
 
     # @param method_name [Symbol] The name of the method being memoized.
-    # @param argument_hash [Integer] The hash value of the arguments passed to the method.
+    # @param args [Array<*>] Arguments passed to the method being memoized.
+    # @param kwargs [Hash] Keyword arguments passed to the method being memoized.
     # @yield [] Yields to a given block with no arguments. Memoizes the value returned by the block.
     # @return [*] The value returned either from the memoization cache if present, or yielded block if not.
-    def memoize(method_name, argument_hash)
-      return memoized_value(method_name, argument_hash) if memoized?(method_name, argument_hash)
+    def memoize(method_name, args, kwargs)
+      argument_hash = [ *args, kwargs ].hash
+
+      value = memoized_value(method_name, argument_hash)
+
+      return value unless value == NOT_MEMOIZED
 
       clear_memoization(method_name) unless current_memoization_for_method?(method_name)
 
@@ -52,26 +59,18 @@ module ShortCircuIt
       memoized_hash[method_name] ||= {}
     end
 
-    # @param method_name [Symbol] The name of the method to memoize
-    # @param argument_hash [Integer] The hash value of the arguments passed to the method
-    # @return [Boolean] True if the method has a current memoized value with the given arguments
-    def memoized?(method_name, argument_hash)
-      current_memoization_for_method?(method_name) && current_memoization_for_method(method_name).key?(argument_hash)
-    end
-
     # @param method_name [String] The name of the method to memoize
     # @param argument_hash [Integer] The hash value of the arguments passed to the method
     # @return [*] The value that has been memoized for the method/argument combination
     def memoized_value(method_name, argument_hash)
-      raise NotMemoizedError unless memoized?(method_name, argument_hash)
-
       current_memoization_for_method(method_name)[argument_hash]
     end
 
     # @param method_name [Symbol] The name of a memoized method
     # @return [Hash] A hash of memoized values for the current state of the observed objects for the given method.
     def current_memoization_for_method(method_name)
-      memoization_for_method(method_name)[state_hash(method_name)] ||= {}
+      # Memoize values inside a hash with default value of NOT_MEMOIZED
+      memoization_for_method(method_name)[state_hash(method_name)] ||= Hash.new(NOT_MEMOIZED)
     end
 
     # @param method_name [Symbol] The name of a memoized method

--- a/short_circu_it/lib/short_circu_it/memoization_store.rb
+++ b/short_circu_it/lib/short_circu_it/memoization_store.rb
@@ -5,6 +5,7 @@ require "active_support/core_ext/module"
 module ShortCircuIt
   class MemoizationStore
     NOT_MEMOIZED = Object.new
+    private_constant :NOT_MEMOIZED
 
     delegate :memoization_observers, to: :owner
 

--- a/short_circu_it/script/short_circuit_bench.rb
+++ b/short_circu_it/script/short_circuit_bench.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "benchmark"
+require_relative "short_circu_it/lib/short_circu_it"
+
+class A
+  include ShortCircuIt
+
+  def ivar_no_args
+    @ivar ||= rand
+  end
+
+  def sc_no_args
+    rand
+  end
+  memoize :sc_no_args
+
+  def sc_no_args_observes_nil
+    rand
+  end
+  memoize :sc_no_args_observes_nil, observes: nil
+
+  def ivar_one_arg(a)
+    @ivar_one_arg ||= {}
+    @ivar_one_arg[a] ||= rand
+  end
+
+  def sc_one_arg(a)
+    rand
+  end
+  memoize :sc_one_arg
+
+  def sc_one_arg_observes_nil(a)
+    rand
+  end
+  memoize :sc_one_arg_observes_nil, observes: nil
+end
+
+n = 10000
+a = A.new
+
+Benchmark.bm do |b|
+  b.report("ivar no arg") { n.times { a.ivar_no_args } }
+  b.report("sc no arg") { n.times { a.sc_no_args } }
+  b.report("sc no arg obs nil") { n.times { a.sc_no_args_observes_nil } }
+
+  b.report("ivar one arg") { n.times { a.ivar_one_arg([1, 2].sample) } }
+  b.report("sc one arg") { n.times { a.sc_one_arg([1, 2].sample) } }
+  b.report("sc one arg obs nil") { n.times { a.sc_one_arg_observes_nil([1, 2].sample) } }
+end

--- a/short_circu_it/script/short_circuit_bench.rb
+++ b/short_circu_it/script/short_circuit_bench.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "benchmark"
-require_relative "short_circu_it/lib/short_circu_it"
+require_relative "../lib/short_circu_it"
 
 class A
   include ShortCircuIt


### PR DESCRIPTION
Removes some redunant (and expensive) calls for ~3x improvement:
```
# Before:
spicerack$ ruby short_circu_it/script/short_circuit_bench.rb 
       user     system      total        real
ivar no arg  0.004852   0.000010   0.004862 (  0.004851)
sc no arg  0.479797   0.000811   0.480608 (  0.480882)
sc no arg obs nil  0.372738   0.000475   0.373213 (  0.373447)
ivar one arg  0.015768   0.000034   0.015802 (  0.015903)
sc one arg  0.491822   0.001098   0.492920 (  0.493536)
sc one arg obs nil  0.390905   0.000707   0.391612 (  0.391910)

# After:
spicerack$ ruby short_circu_it/script/short_circuit_bench.rb 
       user     system      total        real
ivar no arg  0.004859   0.000014   0.004873 (  0.004863)
sc no arg  0.171001   0.000631   0.171632 (  0.171751)
sc no arg obs nil  0.147294   0.000522   0.147816 (  0.149147)
ivar one arg  0.016028   0.000018   0.016046 (  0.016051)
sc one arg  0.179277   0.000495   0.179772 (  0.179896)
sc one arg obs nil  0.154946   0.000267   0.155213 (  0.155329)
```
Still _much_ slower than ivar memoization, but shhhh